### PR TITLE
Fixed LICENSE and README files

### DIFF
--- a/Mini/Mini.csproj
+++ b/Mini/Mini.csproj
@@ -28,6 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Debug\Mini.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Release\Mini.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IniComment.cs" />
@@ -62,8 +64,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="LICENSE.txt" />
-    <Content Include="README.txt" />
+    <None Include="LICENSE.txt" />
+    <None Include="README.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Mini/Mini.nuspec
+++ b/Mini/Mini.nuspec
@@ -11,7 +11,11 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes></releaseNotes>
-    <copyright>Copyright (C) 2013 Samuel Fredrickson</copyright>
+    <copyright>Copyright (C) 2014 Samuel Fredrickson</copyright>
     <tags>ini serialization</tags>
   </metadata>
+  <files>
+    <file src="LICENSE.txt" target="LICENSE.txt"/>
+    <file src="README.txt" target="README.txt"/>
+  </files>
 </package>

--- a/Mini/Properties/AssemblyInfo.cs
+++ b/Mini/Properties/AssemblyInfo.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 // The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
 // If the build and revision are set to '*' they will be updated automatically.
 
-[assembly: AssemblyVersion("0.3.0.0")]
+[assembly: AssemblyVersion("0.4.0.0")]
 
 // The following attributes are used to specify the signing key for the
 // assembly, if desired. See the Mono documentation for more information about


### PR DESCRIPTION
- Changed build action to None for LICENSE and README files and included them in the .nuspec file.
- LICENSE and README will no longer be forcibly added to consumers' projects when they use this package.
- Enabled XML documentation generation.
- Fixed issue #3 
